### PR TITLE
Fix copilot.api to copilot.status API change

### DIFF
--- a/lua/copilot_status/status.lua
+++ b/lua/copilot_status/status.lua
@@ -96,8 +96,8 @@ function Status:new(client)
     buffer = vim.api.nvim_get_current_buf(),
     callback = function()
       if o.client ~= nil and not o.handler_registered then
-        local cp_api = require "copilot.api"
-        cp_api.register_status_notification_handler(status_cb)
+        local cp_status = require "copilot.status"
+        cp_status.register_status_notification_handler(status_cb)
         o.handler_registered = true
       elseif o.client == nil then
         local cp_client_ok, cp_client = pcall(require, "copilot.client")
@@ -112,8 +112,8 @@ function Status:new(client)
     buffer = vim.api.nvim_get_current_buf(),
     callback = function()
       if o.client ~= nil and o.handler_registered then
-        local cp_api = require "copilot.api"
-        cp_api.unregister_status_notification_handler(status_cb)
+        local cp_status = require "copilot.status"
+        cp_status.unregister_status_notification_handler(status_cb)
         o.handler_registered = false
       elseif o.client == nil then
         local cp_client_ok, cp_client = pcall(require, "copilot.client")


### PR DESCRIPTION
Upstream has updated API in backward incompatible way, so this fix is required to keep up with that breaking change.

Upstream https://github.com/zbirenbaum/copilot.lua/commit/d93f32b7b85d1f102288f15d22bc9703e0e9b065#diff-5c5f00d73032c3bd1c15957e1d280771ed8476db931b7e38cc97a9d410fe5ad5L222-L226 (see highlighted block, or just search for `register_status_notification_handler`).

NB: The fix is trivial, but without it -- plugin becomes unusable.